### PR TITLE
fix(api): standardize 404 error responses

### DIFF
--- a/src/api/exceptions.py
+++ b/src/api/exceptions.py
@@ -42,6 +42,6 @@ def handle_not_found_error(e: ValueError) -> None:
         ValueError: Database connection failed
     """
     if "not found" in str(e).lower():
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail="Patient not found")
     raise e
 


### PR DESCRIPTION
fix(api): standardize 404 error responses

This pull request makes a small but important change to the error handling for not found errors in the API. Instead of returning the original error message, it now returns a standardized message when a patient is not found.

* Standardized the error message for 404 responses in `handle_not_found_error` to always return "Patient not found" instead of the original exception message. (`src/api/exceptions.py`)

Resolves issue DEA-86