### PR TITLE
Fix: test storage fixture parameter [#85]

### DIFF
--- a/src/api/exceptions.py
+++ b/src/api/exceptions.py
@@ -44,5 +44,5 @@ def handle_not_found_error(e: ValueError) -> NoReturn:
         ValueError: Database connection failed
     """
     if "not found" in str(e).lower():
-        raise HTTPException(status_code=404, detail="Patient not found")
+        raise HTTPException(status_code=404, detail=str(e))
     raise e

--- a/src/api/exceptions.py
+++ b/src/api/exceptions.py
@@ -42,6 +42,6 @@ def handle_not_found_error(e: ValueError) -> None:
         ValueError: Database connection failed
     """
     if "not found" in str(e).lower():
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail="Patient not found")
     raise e
 

--- a/tests/unit-tests/test_storage.py
+++ b/tests/unit-tests/test_storage.py
@@ -97,10 +97,10 @@ class TestPatientStorage:
         assert result[1].patient_id == 2
         assert result[2].patient_id == 3
 
-    async def test_update_patient_success(self):
+    async def test_update_patient_success(self, patient_data_factory):
         """Test partial update preserves unchanged fields"""
         await self._create_test_patient(
-            1, name="Original", email="original@example.com"
+            patient_data_factory, 1, name="Original", email="original@example.com"
         )
 
         result = await update_patient(1, PatientUpdate(name="Updated"))
@@ -116,9 +116,9 @@ class TestPatientStorage:
         with pytest.raises(ValueError, match="Patient with id 999 not found"):
             await update_patient(999, update_data)
 
-    async def test_delete_patient_success(self):
+    async def test_delete_patient_success(self, patient_data_factory):
         """Test deleting a patient successfully"""
-        await self._create_test_patient(1)
+        await self._create_test_patient(patient_data_factory, 1)
 
         await delete_patient(1)
 


### PR DESCRIPTION
This pull request updates the unit tests in `tests/unit-tests/test_storage.py` to improve test setup flexibility by introducing the `patient_data_factory` fixture to relevant test methods. This change ensures that patient test data can be more easily customized and reused across tests.

Test setup improvements:

* Added the `patient_data_factory` fixture as a parameter to the `test_update_patient_success` method and updated the call to `_create_test_patient` to use this factory.
* Added the `patient_data_factory` fixture as a parameter to the `test_delete_patient_success` method and updated the call to `_create_test_patient` to use this factory.

_Closes DEA-85_